### PR TITLE
Some additional optional values and utf-8 /metrics

### DIFF
--- a/src/hue_client.rs
+++ b/src/hue_client.rs
@@ -52,10 +52,10 @@ pub struct Light {
 pub struct LightState {
     pub reachable: bool,
     pub on: bool,
-    pub bri: i64,
-    pub hue: i64,
-    pub sat: i64,
-    pub ct: i64,
+    pub bri: Option<i64>,
+    pub hue: Option<i64>,
+    pub sat: Option<i64>,
+    pub ct: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,9 @@ async fn metrics(hue_client: web::Data<HueClient>) -> impl Responder {
     let metric_families = prometheus::gather();
     encoder.encode(&metric_families, &mut buffer).unwrap();
 
-    HttpResponse::Ok().body(String::from_utf8(buffer).unwrap())
+    HttpResponse::Ok()
+        .insert_header((header::CONTENT_TYPE, "text/plain; charset=utf-8"))
+        .body(String::from_utf8(buffer).unwrap())
 }
 
 async fn fetch_metrics(hue_client: &HueClient) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,10 +211,10 @@ async fn fetch_metrics(hue_client: &HueClient) -> Result<()> {
         // state metrics -------------------------------------------------
         report_metric!(light, GAUGE_LIGHTS_STATE_REACHABLE, light.state.reachable);
         report_metric!(light, GAUGE_LIGHTS_STATE_ON, light.state.on);
-        report_metric!(light, GAUGE_LIGHTS_STATE_BRI, light.state.bri);
-        report_metric!(light, GAUGE_LIGHTS_STATE_HUE, light.state.hue);
-        report_metric!(light, GAUGE_LIGHTS_STATE_SAT, light.state.sat);
-        report_metric!(light, GAUGE_LIGHTS_STATE_CT, light.state.ct);
+        report_optional_metric!(light, GAUGE_LIGHTS_STATE_BRI, light.state.bri);
+        report_optional_metric!(light, GAUGE_LIGHTS_STATE_HUE, light.state.hue);
+        report_optional_metric!(light, GAUGE_LIGHTS_STATE_SAT, light.state.sat);
+        report_optional_metric!(light, GAUGE_LIGHTS_STATE_CT, light.state.ct);
     }
 
     Ok(())


### PR DESCRIPTION
I made some minor changes to fit my home.

- Made some LightState values optional, since some lights in my network lacks these properties.
- 
- Set utf-8 header for /metrics endpoints as some of my device names contain non-latin characters.
